### PR TITLE
fix broker lists string

### DIFF
--- a/src/main/java/com/couchbase/kafka/CouchbaseKafkaConnector.java
+++ b/src/main/java/com/couchbase/kafka/CouchbaseKafkaConnector.java
@@ -215,7 +215,7 @@ public class CouchbaseKafkaConnector implements Runnable {
             if (first) {
                 first = false;
             } else {
-                sb.append(";");
+                sb.append(",");
             }
             sb.append(item);
         }


### PR DESCRIPTION
brokers lists use `,` , don't use `;`
